### PR TITLE
Add class to count active slides

### DIFF
--- a/dist/tiny-slider.js
+++ b/dist/tiny-slider.js
@@ -2681,18 +2681,28 @@ var tns = function (options) {
   } // update slide
 
 
-  function updateSlideStatus() {
+  // update slide
+  function updateSlideStatus () {
     var range = getVisibleSlideRange(),
         start = range[0],
         end = range[1];
-    forEach(slideItems, function (item, i) {
+
+    forEach(slideItems, function(item, i) {
+      forEach(item.classList, function(className) {
+        if (typeof className == 'string' && className.startsWith(slideActiveClass + '-')) {
+          removeClass(item, className);
+        }
+      });
+      
       // show slides
       if (i >= start && i <= end) {
+        addClass(item, slideActiveClass + '-' + (i - start));
+      
         if (hasAttr(item, 'aria-hidden')) {
           removeAttrs(item, ['aria-hidden', 'tabindex']);
           addClass(item, slideActiveClass);
-        } // hide slides
-
+        }
+      // hide slides
       } else {
         if (!hasAttr(item, 'aria-hidden')) {
           setAttrs(item, {
@@ -2703,7 +2713,7 @@ var tns = function (options) {
         }
       }
     });
-  } // gallery: update slide position
+  }
 
 
   function updateGallerySlidePositions() {

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1932,8 +1932,16 @@ export var tns = function(options) {
         end = range[1];
 
     forEach(slideItems, function(item, i) {
+      forEach(item.classList, function(className) {
+        if (typeof className == 'string' && className.startsWith(slideActiveClass + '-')) {
+          removeClass(item, className);
+        }
+      });
+      
       // show slides
       if (i >= start && i <= end) {
+        addClass(item, slideActiveClass + '-' + (i - start));
+      
         if (hasAttr(item, 'aria-hidden')) {
           removeAttrs(item, ['aria-hidden', 'tabindex']);
           addClass(item, slideActiveClass);


### PR DESCRIPTION
This adds an additional class to each active slide in the form of `tns-slide-active-[nth]` where `[nth]` is the counted up from the first active slide.

E.g., if 3 slides are active, they will be assigned the following classes respectively:
```
.tns-slide-active-0
.tns-slide-active-1
.tns-slide-active-2
```

This allows them to be styled. Differently. For instance, the first and last slides can be blurred as requested in https://github.com/ganlanyuan/tiny-slider/issues/586.